### PR TITLE
prevent DEFAULT_REGION's deprecation message to always show

### DIFF
--- a/localstack/config.py
+++ b/localstack/config.py
@@ -340,9 +340,9 @@ except ImportError:
     pass
 
 # default AWS region
-if "DEFAULT_REGION" not in os.environ:
-    os.environ["DEFAULT_REGION"] = os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1
-DEFAULT_REGION = os.environ["DEFAULT_REGION"]
+DEFAULT_REGION = (
+    os.environ.get("DEFAULT_REGION") or os.environ.get("AWS_DEFAULT_REGION") or AWS_REGION_US_EAST_1
+)
 
 # expose services on a specific host externally
 HOSTNAME_EXTERNAL = os.environ.get("HOSTNAME_EXTERNAL", "").strip() or LOCALHOST

--- a/localstack/deprecations.py
+++ b/localstack/deprecations.py
@@ -189,7 +189,7 @@ def deprecated_endpoint(
     """
     Wrapper function which logs a warning (and a deprecation path) whenever a deprecated URL is invoked by a router.
 
-    :param endpoint: to wrap (log a warning whenevery it is invoked)
+    :param endpoint: to wrap (log a warning whenever it is invoked)
     :param previous_path: route path it is triggered by
     :param deprecation_version: version of LocalStack with which this endpoint is deprecated
     :param new_path: new route path which should be used instead


### PR DESCRIPTION
### prevent DEFAULT_REGION's deprecation message to always show

Whenever we start localstack we're greeting with this warning message:

```
WARN --- [  MainThread] localstack.deprecations    : DEFAULT_REGION is deprecated (since 0.12.7) and will be removed in upcoming releases of LocalStack! LocalStack now has full multi-region support. Please remove this environment variable.
```

This happens even if we don't have the environment variable `DEFAULT_REGION` set.
This is because in `localstack/config.py` the check for the environment variable has a side effect of creating it if the environment variable is not set!

Later on the detection `log_deprecation_warnings()` checks kick-in and detect that the environment variable is set and issue the warning.

With this commit we're avoiding creating the environment variable.

See https://github.com/localstack/localstack/issues/7257#issuecomment-1351278444

### fix a typo in the python doc